### PR TITLE
[feat]'잃었어요'&'주웠어요' 게시글 생성 api/삭제 api 구현

### DIFF
--- a/ajoufinder/src/main/java/com/ajoufinder/api/controller/board/BoardController.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/controller/board/BoardController.java
@@ -1,4 +1,40 @@
 package com.ajoufinder.api.controller.board;
 
+import com.ajoufinder.api.controller.board.dto.request.BoardCreateRequestDto;
+import com.ajoufinder.api.controller.board.dto.response.BoardCreateResponseDto;
+import com.ajoufinder.api.service.board.BoardCommandService;
+import com.ajoufinder.api.service.board.BoardQueryService;
+import com.ajoufinder.domain.board.entity.Board;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("api/v1/boards")
+@RequiredArgsConstructor
 public class BoardController {
+  private final BoardQueryService boardQueryService;
+  private final BoardCommandService boardCommandService;
+
+  @PostMapping("/lost")
+  public ResponseEntity<BoardCreateResponseDto> createLostBoard(@RequestBody @Valid BoardCreateRequestDto requestDto) {
+    Board board=boardCommandService.createLostBoard(requestDto);
+    BoardCreateResponseDto responseDto = BoardCreateResponseDto.from(board);
+    return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
+  }
+
+  @PostMapping("/found")
+  public ResponseEntity<BoardCreateResponseDto> createFoundBoard(@RequestBody @Valid BoardCreateRequestDto requestDto) {
+    Board board=boardCommandService.createFoundBoard(requestDto);
+    BoardCreateResponseDto responseDto = BoardCreateResponseDto.from(board);
+    return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
+  }
+
+  @DeleteMapping("/{boardId}")
+  public ResponseEntity<Void>deleteBoard(@PathVariable Long boardId){
+    boardCommandService.deleteBoard(boardId);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
 }

--- a/ajoufinder/src/main/java/com/ajoufinder/api/controller/board/dto/request/BoardCreateRequestDto.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/controller/board/dto/request/BoardCreateRequestDto.java
@@ -1,0 +1,60 @@
+package com.ajoufinder.api.controller.board.dto.request;
+
+import com.ajoufinder.common.valid.annotation.ValidEnum;
+import com.ajoufinder.domain.board.entity.Board;
+import com.ajoufinder.domain.board.entity.constant.BoardCategory;
+import com.ajoufinder.domain.board.entity.constant.BoardStatus;
+import com.ajoufinder.domain.board.entity.constant.ItemType;
+import com.ajoufinder.domain.location.entity.Location;
+import com.ajoufinder.domain.user.entity.User;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record BoardCreateRequestDto(
+        @NotNull(message="사용자는 필수 입력값입니다.")
+        Long userId,
+
+        @NotNull(message="위치는 필수 입력값입니다.")
+        Long locationId,
+
+        @NotNull(message="아이템 종류는 필수 입력값입니다.")
+        @ValidEnum(enumClass = ItemType.class, message = "유효하지 않은 아이템 종류입니다.")
+        ItemType itemType,
+
+        @Size(max = 100, message = "상세 위치는 최대 100자까지 허용됩니다.")
+        String detailedLocation,
+
+        @NotBlank(message="제목은 필수 입력값입니다.")
+        @Size(max = 255, message = "제목은 최대 255자까지 허용됩니다.")
+        String title,
+
+        @NotBlank(message="내용은 필수 입력값입니다.")
+        String description,
+
+        @NotNull(message="습득 날짜는 필수 입력값입니다.")
+        LocalDateTime relatedDate,
+
+        @Size(max = 255, message = "상세 위치는 최대 255자까지 허용됩니다.")
+        String imageUrl
+){
+  public Board toEntity(User user, Location location,BoardCategory category) {
+    return Board.builder().user(user)
+            .location(location)
+            .detailedLocation(detailedLocation)
+            .itemType(itemType)
+            .title(title)
+            .description(description)
+            .relatedDate(relatedDate)
+            .imageUrl(imageUrl)
+            .category(category)
+            .status(BoardStatus.IN_PROGRESS)
+            .build();
+  }
+}

--- a/ajoufinder/src/main/java/com/ajoufinder/api/controller/board/dto/response/BoardCreateResponseDto.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/controller/board/dto/response/BoardCreateResponseDto.java
@@ -1,0 +1,16 @@
+package com.ajoufinder.api.controller.board.dto.response;
+
+import com.ajoufinder.domain.board.entity.Board;
+import lombok.Builder;
+
+@Builder
+public record BoardCreateResponseDto(
+        Long boardId,
+        String message
+){
+public static BoardCreateResponseDto from(Board board) {
+  return BoardCreateResponseDto.builder().boardId(board.getBoardId())
+          .message("'"+board.getCategory().getText()+"' 게시글이 성공적으로 생성되었습니다.")
+          .build();
+}
+}

--- a/ajoufinder/src/main/java/com/ajoufinder/api/controller/user/UserController.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/controller/user/UserController.java
@@ -2,8 +2,10 @@ package com.ajoufinder.api.controller.user;
 
 import com.ajoufinder.api.controller.user.dto.request.UserCreateRequestDto;
 import com.ajoufinder.api.controller.user.dto.request.UserLoginRequestDto;
+import com.ajoufinder.api.controller.user.dto.response.UserCreateResponseDto;
 import com.ajoufinder.api.service.user.UserCommandService;
 import com.ajoufinder.api.service.user.UserQueryService;
+import com.ajoufinder.domain.user.entity.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,9 +21,10 @@ public class UserController {
   private final UserQueryService userQueryService;
 
   @PostMapping("/register")
-  public ResponseEntity<Void> register(@RequestBody @Valid UserCreateRequestDto dto) {
-    userCommandService.createUser(dto);
-    return ResponseEntity.status(HttpStatus.CREATED).build();
+  public ResponseEntity<UserCreateResponseDto> register(@RequestBody @Valid UserCreateRequestDto requestDto) {
+    User user=userCommandService.createUser(requestDto);
+    UserCreateResponseDto responseDto = UserCreateResponseDto.from(user);
+    return new ResponseEntity<>(responseDto,HttpStatus.CREATED);
   }
 
   @PostMapping("/login")

--- a/ajoufinder/src/main/java/com/ajoufinder/api/controller/user/dto/response/UserCreateResponseDto.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/controller/user/dto/response/UserCreateResponseDto.java
@@ -1,0 +1,16 @@
+package com.ajoufinder.api.controller.user.dto.response;
+
+import com.ajoufinder.domain.user.entity.User;
+import lombok.Builder;
+
+@Builder
+public record UserCreateResponseDto(
+        Long userId,
+        String message
+) {
+  public static UserCreateResponseDto from(User user) {
+    return UserCreateResponseDto.builder().userId(user.getUserId())
+            .message("회원가입 성공")
+            .build();
+  }
+}

--- a/ajoufinder/src/main/java/com/ajoufinder/api/service/board/BoardCommandService.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/service/board/BoardCommandService.java
@@ -1,0 +1,49 @@
+package com.ajoufinder.api.service.board;
+
+import com.ajoufinder.api.controller.board.dto.request.BoardCreateRequestDto;
+import com.ajoufinder.api.service.location.LocationQueryService;
+import com.ajoufinder.api.service.user.UserQueryService;
+import com.ajoufinder.domain.board.entity.Board;
+import com.ajoufinder.domain.board.entity.constant.BoardCategory;
+import com.ajoufinder.domain.board.entity.constant.BoardStatus;
+import com.ajoufinder.domain.board.repository.BoardRepository;
+import com.ajoufinder.domain.location.entity.Location;
+import com.ajoufinder.domain.user.entity.User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BoardCommandService {
+  private final BoardRepository boardRepository;
+  private final LocationQueryService locationQueryService;
+  private final UserQueryService userQueryService;
+  private final BoardQueryService boardQueryService;
+
+  public Board createBoard(BoardCreateRequestDto requestDto,BoardCategory boardCategory) {
+    Long userId=requestDto.userId();
+    User user=userQueryService.getUserByIdOrThrow(userId);
+    Long locationId=requestDto.locationId();
+    Location location=locationQueryService.findLocationByIdOrThrow(locationId);
+    Board board=requestDto.toEntity(user, location, boardCategory);
+    return boardRepository.save(board);
+  }
+
+  public Board createFoundBoard(BoardCreateRequestDto requestDto) {
+    return createBoard(requestDto, BoardCategory.FIND);
+  }
+
+  public Board createLostBoard(BoardCreateRequestDto requestDto) {
+    return createBoard(requestDto, BoardCategory.LOST);
+  }
+
+  public void deleteBoard(Long boardId) {
+    Board board = boardQueryService.getBoardByIdOrThrow(boardId);
+    board.changeStatus(BoardStatus.DELETED);
+    boardRepository.save(board);
+  }
+}

--- a/ajoufinder/src/main/java/com/ajoufinder/api/service/board/BoardQueryService.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/service/board/BoardQueryService.java
@@ -1,0 +1,19 @@
+package com.ajoufinder.api.service.board;
+
+import com.ajoufinder.common.exception.ExceptionCode;
+import com.ajoufinder.common.exception.board.BoardException;
+import com.ajoufinder.domain.board.entity.Board;
+import com.ajoufinder.domain.board.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class BoardQueryService {
+  private final BoardRepository boardRepository;
+
+  public Board getBoardByIdOrThrow(Long boardId) {
+    return boardRepository.findById(boardId).orElseThrow(()->new BoardException(ExceptionCode.NOT_FOUND_BOARD));
+  }
+}

--- a/ajoufinder/src/main/java/com/ajoufinder/api/service/location/LocationCommandService.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/service/location/LocationCommandService.java
@@ -1,0 +1,10 @@
+package com.ajoufinder.api.service.location;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class LocationCommandService {
+}

--- a/ajoufinder/src/main/java/com/ajoufinder/api/service/location/LocationQueryService.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/service/location/LocationQueryService.java
@@ -1,0 +1,21 @@
+package com.ajoufinder.api.service.location;
+
+import com.ajoufinder.common.exception.ExceptionCode;
+import com.ajoufinder.common.exception.location.LocationException;
+import com.ajoufinder.domain.location.entity.Location;
+import com.ajoufinder.domain.location.repository.LocationRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class LocationQueryService {
+  private final LocationRepository locationRepository;
+
+  public Location findLocationByIdOrThrow(Long locationId) {
+    return locationRepository.findById(locationId).orElseThrow(
+            ()->new LocationException(ExceptionCode.NOT_FOUND_LOCATION));
+  }
+}

--- a/ajoufinder/src/main/java/com/ajoufinder/api/service/user/UserQueryService.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/service/user/UserQueryService.java
@@ -1,5 +1,9 @@
 package com.ajoufinder.api.service.user;
 
+import com.ajoufinder.common.exception.AjouFinderException;
+import com.ajoufinder.common.exception.ExceptionCode;
+import com.ajoufinder.common.exception.user.UserException;
+import com.ajoufinder.domain.user.entity.User;
 import com.ajoufinder.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -9,5 +13,16 @@ import org.springframework.stereotype.Service;
 public class UserQueryService {
   private final UserRepository userRepository;
 
+  public User getUserByIdOrThrow(Long userId) {
+    return userRepository.findById(userId).orElseThrow(
+            ()->new UserException(ExceptionCode.NOT_FOUND_MEMBER));
+  }
 
+  public boolean existsByEmail(String email) {
+    return userRepository.existsByEmail(email);
+  }
+
+  public boolean existsByNickname(String nickname) {
+    return userRepository.existsByNickname(nickname);
+  }
 }

--- a/ajoufinder/src/main/java/com/ajoufinder/common/config/SecurityConfig.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/common/config/SecurityConfig.java
@@ -3,16 +3,35 @@ package com.ajoufinder.common.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.annotation.SecurityBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
-@EnableWebFluxSecurity
+@EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
   @Bean
   public PasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http
+            .csrf().disable() // CSRF 보호 비활성화
+            .authorizeHttpRequests(authorize -> authorize
+                    .requestMatchers(
+                            "/v3/api-docs/**",         // OpenAPI 문서 경로
+                            "/swagger-ui/**",          // Swagger UI 경로
+                            "/swagger-ui/index.html",  // Swagger UI 인덱스
+                            "/webjars/**"              // Swagger UI에 필요한 웹 자원
+                    ).permitAll() // 인증 없이 접근 허용
+                    .anyRequest().permitAll() // 모든 요청에 대해 접근 허용
+            );
+    return http.build();
   }
 }

--- a/ajoufinder/src/main/java/com/ajoufinder/common/exception/ExceptionCode.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/common/exception/ExceptionCode.java
@@ -8,7 +8,16 @@ import lombok.RequiredArgsConstructor;
 public enum ExceptionCode{
   //User
   DUPLICATED_USER_EMAIL(409, "이미 존재하는 이메일입니다."),
-  DUPLICATED_USER_NICKNAME(409, "이미 존재하는 닉네임입니다.");
+  DUPLICATED_USER_NICKNAME(409, "이미 존재하는 닉네임입니다."),
+  NOT_FOUND_MEMBER(404, "존재하지 않는 멤버입니다."),
+
+  //Location
+  NOT_FOUND_LOCATION(404, "존재하지 않는 위치입니다."),
+
+  //Board
+  NOT_FOUND_BOARD(404, "존재하지 않는 게시물입니다.");
+
+
   private final int code;
   private final String message;
 }

--- a/ajoufinder/src/main/java/com/ajoufinder/common/exception/location/LocationException.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/common/exception/location/LocationException.java
@@ -1,0 +1,10 @@
+package com.ajoufinder.common.exception.location;
+
+import com.ajoufinder.common.exception.AjouFinderException;
+import com.ajoufinder.common.exception.ExceptionCode;
+
+public class LocationException extends AjouFinderException {
+  public LocationException(ExceptionCode exceptionCode) {
+    super(exceptionCode);
+  }
+}

--- a/ajoufinder/src/main/java/com/ajoufinder/common/valid/annotation/ValidEnum.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/common/valid/annotation/ValidEnum.java
@@ -1,0 +1,20 @@
+package com.ajoufinder.common.valid.annotation;
+
+import com.ajoufinder.common.valid.validator.EnumValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = EnumValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidEnum {
+  String message() default "유효하지 않은 값입니다.";
+  Class<?>[] groups() default {};
+  Class<? extends Payload>[] payload() default {};
+  Class<? extends Enum<?>> enumClass();
+}

--- a/ajoufinder/src/main/java/com/ajoufinder/common/valid/validator/EnumValidator.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/common/valid/validator/EnumValidator.java
@@ -1,0 +1,27 @@
+package com.ajoufinder.common.valid.validator;
+
+import com.ajoufinder.common.valid.annotation.ValidEnum;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class EnumValidator implements ConstraintValidator<ValidEnum, Enum> {
+  private Enum<?>[] enumConstants;
+
+  @Override
+  public void initialize(ValidEnum constraintAnnotation) {
+    this.enumConstants = constraintAnnotation.enumClass().getEnumConstants();
+  }
+
+  @Override
+  public boolean isValid(Enum value, ConstraintValidatorContext context) {
+    if (value == null) {
+     return true;
+    }
+    for (Enum<?> enumValue : enumConstants) {
+      if (enumValue.name().equals(value.name())) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/ajoufinder/src/main/java/com/ajoufinder/domain/board/entity/Board.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/domain/board/entity/Board.java
@@ -83,4 +83,8 @@ public class Board extends TimeStamp {
     this.location = location;
     location.getBoards().add(this);
   }
+
+  public void changeStatus(BoardStatus status){
+    this.status = status;
+  }
 }

--- a/ajoufinder/src/main/java/com/ajoufinder/domain/board/entity/Board.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/domain/board/entity/Board.java
@@ -8,12 +8,16 @@ import com.ajoufinder.domain.location.entity.Location;
 import com.ajoufinder.domain.user.entity.User;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Board extends TimeStamp {
   @Id
   @GeneratedValue(strategy=GenerationType.IDENTITY)
@@ -56,6 +60,20 @@ public class Board extends TimeStamp {
   @Enumerated(EnumType.STRING)
   @Column(name="item_type",nullable=false)
   private ItemType itemType;
+
+  @Builder
+  public Board(User user,Location location,String title,String description,LocalDateTime relatedDate,String imageUrl,BoardStatus status,BoardCategory category,String detailedLocation,ItemType itemType){
+    this.user = user;
+    this.location = location;
+    this.title = title;
+    this.description = description;
+    this.relatedDate = relatedDate;
+    this.imageUrl = imageUrl;
+    this.status = status;
+    this.category = category;
+    this.detailedLocation = detailedLocation;
+    this.itemType = itemType;
+  }
 
   public void assignUser(User user){
     this.user = user;


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #11

## 📌 작업 사항 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
 1. Enum 검증 애노테이션과 검증기 구현
 2. Board 및 Location 관련 ExceptionCode 추가
 3. BoardCreateRequestdto 구현
 4. Controller에 게시글 생성/삭제 api 구현
 5. BoardCommandService 에 게시글 생성/삭제 로직 구현
 6. 게시글 생성 시 locationId와 userId에 대한 유효성 검사를 위해 위치 조회와 사용자 조회 함수 추가
 7. Location 기본 Service 클래스 생성
 8. UserCreateRequestDto에 category 변수 @NotNull로 변경(String 이 아닌 모든 참조변수는 비어있는지 확인할 때 @NotNull 사용하므로)
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
요구사항:
1. 사용자는 물건을 분실했을 때 ‘잃었어요’&‘주웠어요’ 카테고리로 게시글을 작성할 수 있다.
2. 사용자는 자신이 작성한 게시글을 삭제할 수 있다. 

수용 기준:
• 저장된 게시글에는 자동으로 생성일과 수정일이 기록된다.
• 인증된 사용자만 게시글 생성이 가능하다.(추후구현)
• 자신이 작성한 게시글만 삭제가 가능하다.(추후구현)

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
