### PR TITLE
[feat] 위치 생성&삭제 로직 구현

### DIFF
--- a/ajoufinder/src/main/java/com/ajoufinder/AjoufinderApplication.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/AjoufinderApplication.java
@@ -2,8 +2,10 @@ package com.ajoufinder;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class AjoufinderApplication {
 
   public static void main(String[] args) {

--- a/ajoufinder/src/main/java/com/ajoufinder/api/controller/location/LocationController.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/controller/location/LocationController.java
@@ -1,4 +1,30 @@
 package com.ajoufinder.api.controller.location;
 
+import com.ajoufinder.api.controller.location.dto.request.LocationCreateRequestDto;
+import com.ajoufinder.api.service.location.LocationCommandService;
+import com.ajoufinder.api.service.location.LocationQueryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/locations")
+@RequiredArgsConstructor
 public class LocationController {
+  private final LocationCommandService locationCommandService;
+  private final LocationQueryService locationQueryService;
+
+  @PostMapping
+  public ResponseEntity<String> createLocation(@RequestBody @Valid LocationCreateRequestDto requestDto) {
+    locationCommandService.createLocation(requestDto);
+    return new ResponseEntity<>("새로운 위치가 성공적으로 추가되었습니다.",HttpStatus.CREATED);
+  }
+
+  @DeleteMapping("/{locationId}")
+  public ResponseEntity<Void> deleteLocation(@PathVariable Long locationId) {
+    locationCommandService.deleteLocation(locationId);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
 }

--- a/ajoufinder/src/main/java/com/ajoufinder/api/controller/location/dto/request/LocationCreateRequestDto.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/controller/location/dto/request/LocationCreateRequestDto.java
@@ -1,0 +1,16 @@
+package com.ajoufinder.api.controller.location.dto.request;
+
+import com.ajoufinder.domain.location.entity.Location;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotBlank;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record LocationCreateRequestDto(
+        @NotBlank(message="위치/건물명은 필수 입력값입니다.")
+        String locationName
+){
+  public Location toEntity() {
+    return Location.builder().locationName(locationName).build();
+  }
+}

--- a/ajoufinder/src/main/java/com/ajoufinder/api/service/location/LocationCommandService.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/service/location/LocationCommandService.java
@@ -1,10 +1,34 @@
 package com.ajoufinder.api.service.location;
 
+import com.ajoufinder.api.controller.location.dto.request.LocationCreateRequestDto;
+import com.ajoufinder.common.exception.ExceptionCode;
+import com.ajoufinder.common.exception.location.LocationException;
+import com.ajoufinder.domain.location.entity.Location;
+import com.ajoufinder.domain.location.entity.constant.LocationStatus;
+import com.ajoufinder.domain.location.repository.LocationRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
+@Transactional
 @Service
 public class LocationCommandService {
+  private final LocationRepository locationRepository;
+  private final LocationQueryService locationQueryService;
+
+  public void createLocation(LocationCreateRequestDto requestDto) {
+    String locationName=requestDto.locationName();
+    if(locationRepository.existsByLocationName(locationName)){
+      throw new LocationException(ExceptionCode.DUPLICATED_LOCATION);
+    }
+    locationRepository.save(requestDto.toEntity());
+  }
+
+  public void deleteLocation(Long locationId) {
+    Location location=locationQueryService.findLocationByIdOrThrow(locationId);
+    location.changeStatus(LocationStatus.DELETED);
+    locationRepository.save(location);
+  }
 }

--- a/ajoufinder/src/main/java/com/ajoufinder/common/exception/ExceptionCode.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/common/exception/ExceptionCode.java
@@ -13,7 +13,7 @@ public enum ExceptionCode{
 
   //Location
   NOT_FOUND_LOCATION(404, "존재하지 않는 위치입니다."),
-
+  DUPLICATED_LOCATION(409, "이미 존재하는 위치입니다."),
   //Board
   NOT_FOUND_BOARD(404, "존재하지 않는 게시물입니다.");
 

--- a/ajoufinder/src/main/java/com/ajoufinder/domain/location/entity/Location.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/domain/location/entity/Location.java
@@ -2,15 +2,19 @@ package com.ajoufinder.domain.location.entity;
 
 import com.ajoufinder.domain.TimeStamp;
 import com.ajoufinder.domain.board.entity.Board;
+import com.ajoufinder.domain.location.entity.constant.LocationStatus;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class Location extends TimeStamp {
   @Id
   @GeneratedValue(strategy=GenerationType.IDENTITY)
@@ -20,8 +24,20 @@ public class Location extends TimeStamp {
   @Column(name="location_name", length = 100)
   private String locationName;
 
+  @Enumerated(EnumType.STRING)
+  private LocationStatus status;
+
   @OneToMany(mappedBy="location",fetch = FetchType.LAZY)
   @JsonManagedReference
   private List<Board>boards=new ArrayList<>();
 
+  @Builder
+  public Location(String locationName) {
+    this.locationName = locationName;
+    this.status=LocationStatus.ACTIVE;
+  }
+
+  public void changeStatus(LocationStatus newStatus) {
+    this.status=newStatus;
+  }
 }

--- a/ajoufinder/src/main/java/com/ajoufinder/domain/location/entity/constant/LocationStatus.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/domain/location/entity/constant/LocationStatus.java
@@ -1,0 +1,6 @@
+package com.ajoufinder.domain.location.entity.constant;
+
+public enum LocationStatus {
+  ACTIVE,
+  DELETED
+}

--- a/ajoufinder/src/main/java/com/ajoufinder/domain/location/repository/LocationRepository.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/domain/location/repository/LocationRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LocationRepository extends JpaRepository<Location, Long> {
+  boolean existsByLocationName(String locationName);
 }


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #16

## 📌 작업 사항 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
1. LocationCreateRequestDto 구현
2. LocationRepository에 같은 locationName이 존재하는지 확인하는 메소드 추가
3.  LocationStatus 추가
4. LocationCommandService에 Location 삭제&생성 로직 구현
5. LocationController에 삭제&생성 api 구현
6. Location 에 상태 저장하는 status 필드 추가
7. Location 중복예외코드 추가
8. JPA Auditing 활성화 설정 추가

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1. 관리자는 새로운 위치를 추가할 수 있다.

> 입력 필드: 건물 이름

> 수용 기준:
• 관리자가 모든 필드를 입력하면 새로운 위치가 저장된다.
• 저장된 위치는 게시물 작성 시 위치로 선택할 수 있다.
• 중복된 건물 이름이 등록되지 않도록 한다.

2. 관리자는 사용하지 않는 위치 정보를 삭제할 수 있다.

> 동작: 위치 삭제 시 해당 위치와 관련된 게시물도 함께 참조를 해제하거나 삭제 상태로 변경

> 수용 기준:
• 해당 위치와 연결된 게시물이 있는 경우 삭제 전에 경고 메시지를 표시한다.
• 삭제된 위치는 게시물 작성 시 선택할 수 없으며, 기존 게시물에서는 연결이 해제되거나 상태가 변경된다.

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
