### PR TITLE
[feat]‘주웠어요’&‘잃었어요’ 게시글 리스트 조회

### DIFF
--- a/ajoufinder/src/main/java/com/ajoufinder/api/controller/board/BoardController.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/controller/board/BoardController.java
@@ -3,11 +3,16 @@ package com.ajoufinder.api.controller.board;
 import com.ajoufinder.api.controller.board.dto.request.BoardCreateRequestDto;
 import com.ajoufinder.api.controller.board.dto.response.BoardCreateResponseDto;
 import com.ajoufinder.api.controller.board.dto.response.BoardDetailInfoResponseDto;
+import com.ajoufinder.api.controller.board.dto.response.BoardSimpleInfoResponseDto;
 import com.ajoufinder.api.service.board.BoardCommandService;
 import com.ajoufinder.api.service.board.BoardQueryService;
 import com.ajoufinder.domain.board.entity.Board;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -26,17 +31,29 @@ public class BoardController {
     return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
   }
 
+  @PostMapping("/found")
+  public ResponseEntity<BoardCreateResponseDto> createFoundBoard(@RequestBody @Valid BoardCreateRequestDto requestDto) {
+    Board board=boardCommandService.createFoundBoard(requestDto);
+    BoardCreateResponseDto responseDto = BoardCreateResponseDto.from(board);
+    return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
+  }
+
   @GetMapping("/{boardId}")
   public ResponseEntity<BoardDetailInfoResponseDto> getBoard(@PathVariable Long boardId) {
     BoardDetailInfoResponseDto boardDetailInfoResponseDto=boardQueryService.getBoard(boardId);
     return new ResponseEntity<>(boardDetailInfoResponseDto, HttpStatus.OK);
   }
 
-  @PostMapping("/found")
-  public ResponseEntity<BoardCreateResponseDto> createFoundBoard(@RequestBody @Valid BoardCreateRequestDto requestDto) {
-    Board board=boardCommandService.createFoundBoard(requestDto);
-    BoardCreateResponseDto responseDto = BoardCreateResponseDto.from(board);
-    return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
+  @GetMapping("/lost")
+  public ResponseEntity<Page<BoardSimpleInfoResponseDto>> getLostBoards(@PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable){
+    Page<BoardSimpleInfoResponseDto> boards=boardQueryService.getLostBoards(pageable);
+    return new ResponseEntity<>(boards, HttpStatus.OK);
+  }
+
+  @GetMapping("/found")
+  public ResponseEntity<Page<BoardSimpleInfoResponseDto>> getFoundBoards(@PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable){
+    Page<BoardSimpleInfoResponseDto> boards=boardQueryService.getFoundBoards(pageable);
+    return new ResponseEntity<>(boards, HttpStatus.OK);
   }
 
   @DeleteMapping("/{boardId}")

--- a/ajoufinder/src/main/java/com/ajoufinder/api/controller/board/dto/response/BoardSimpleInfoResponseDto.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/controller/board/dto/response/BoardSimpleInfoResponseDto.java
@@ -1,0 +1,17 @@
+package com.ajoufinder.api.controller.board.dto.response;
+
+import com.ajoufinder.domain.board.entity.constant.ItemType;
+
+import java.time.LocalDateTime;
+
+public record BoardSimpleInfoResponseDto(
+        Long userId,
+        String nickname,
+        Long locationId,
+        String locationName,
+        String title,
+        LocalDateTime relatedDate,
+        ItemType itemType
+) {
+
+}

--- a/ajoufinder/src/main/java/com/ajoufinder/api/controller/board/dto/response/BoardSimpleInfoResponseDto.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/controller/board/dto/response/BoardSimpleInfoResponseDto.java
@@ -5,6 +5,7 @@ import com.ajoufinder.domain.board.entity.constant.ItemType;
 import java.time.LocalDateTime;
 
 public record BoardSimpleInfoResponseDto(
+        Long boardId,
         Long userId,
         String nickname,
         Long locationId,

--- a/ajoufinder/src/main/java/com/ajoufinder/api/service/board/BoardQueryService.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/service/board/BoardQueryService.java
@@ -1,11 +1,14 @@
 package com.ajoufinder.api.service.board;
 
 import com.ajoufinder.api.controller.board.dto.response.BoardDetailInfoResponseDto;
+import com.ajoufinder.api.controller.board.dto.response.BoardSimpleInfoResponseDto;
 import com.ajoufinder.common.exception.ExceptionCode;
 import com.ajoufinder.common.exception.board.BoardException;
 import com.ajoufinder.domain.board.entity.Board;
 import com.ajoufinder.domain.board.repository.BoardRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 
@@ -24,5 +27,13 @@ public class BoardQueryService {
       throw new BoardException(ExceptionCode.NOT_FOUND_BOARD);
     }
     return boardDetailInfoResponseDto;
+  }
+
+  public Page<BoardSimpleInfoResponseDto> getLostBoards(Pageable pageable) {
+    return boardRepository.getAllLostBoards(pageable);
+  }
+
+  public Page<BoardSimpleInfoResponseDto> getFoundBoards(Pageable pageable) {
+    return boardRepository.getAllFoundBoards(pageable);
   }
 }

--- a/ajoufinder/src/main/java/com/ajoufinder/domain/board/repository/custom/BoardRepositoryCustom.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/domain/board/repository/custom/BoardRepositoryCustom.java
@@ -1,8 +1,15 @@
 package com.ajoufinder.domain.board.repository.custom;
 
 import com.ajoufinder.api.controller.board.dto.response.BoardDetailInfoResponseDto;
+import com.ajoufinder.api.controller.board.dto.response.BoardSimpleInfoResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 
 public interface BoardRepositoryCustom {
   BoardDetailInfoResponseDto findBoardWithUserAndLocation(Long boardId);
+
+  Page<BoardSimpleInfoResponseDto> getAllLostBoards(Pageable pageable);
+
+  Page<BoardSimpleInfoResponseDto> getAllFoundBoards(Pageable pageable);
 }

--- a/ajoufinder/src/main/java/com/ajoufinder/domain/board/repository/custom/BoardRepositoryCustomImpl.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/domain/board/repository/custom/BoardRepositoryCustomImpl.java
@@ -1,18 +1,30 @@
 package com.ajoufinder.domain.board.repository.custom;
 
 import com.ajoufinder.api.controller.board.dto.response.BoardDetailInfoResponseDto;
+import com.ajoufinder.api.controller.board.dto.response.BoardSimpleInfoResponseDto;
+import com.ajoufinder.domain.board.entity.Board;
 import com.ajoufinder.domain.board.entity.QBoard;
+import com.ajoufinder.domain.board.entity.constant.BoardCategory;
+import com.ajoufinder.domain.board.entity.constant.BoardStatus;
 import com.ajoufinder.domain.location.entity.QLocation;
 import com.ajoufinder.domain.user.entity.QUser;
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Repository
 @RequiredArgsConstructor
-public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
+public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
   private final JPAQueryFactory queryFactory;
 
   public BoardDetailInfoResponseDto findBoardWithUserAndLocation(Long boardId) {
@@ -43,4 +55,71 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
             .where(board.boardId.eq(boardId))
             .fetchOne();
   }
+
+  @Override
+  public Page<BoardSimpleInfoResponseDto> getAllLostBoards(Pageable pageable) {
+    QBoard board = QBoard.board;
+
+    List<Board> boards = queryFactory
+            .selectFrom(board)
+            .where(board.category.eq(BoardCategory.LOST)
+                    .and(board.status.ne(BoardStatus.DELETED)))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+    List<BoardSimpleInfoResponseDto> dtoList = boards.stream()
+            .map(boardEntity -> new BoardSimpleInfoResponseDto(
+                    boardEntity.getUser().getUserId(),
+                    boardEntity.getUser().getNickname(),
+                    boardEntity.getLocation() != null ? boardEntity.getLocation().getLocationId() : null,
+                    boardEntity.getLocation() != null ? boardEntity.getLocation().getLocationName() : null,
+                    boardEntity.getTitle(),
+                    boardEntity.getRelatedDate(),
+                    boardEntity.getItemType()
+            ))
+            .collect(Collectors.toList());
+
+    long total = queryFactory
+            .selectFrom(board)
+            .where(board.category.eq(BoardCategory.FIND)
+                    .and(board.status.ne(BoardStatus.DELETED)))
+            .fetchCount();
+
+    return new PageImpl<>(dtoList, pageable, total);
+  }
+
+
+  public Page<BoardSimpleInfoResponseDto> getAllFoundBoards(Pageable pageable) {
+    QBoard board = QBoard.board;
+
+    List<Board> boards = queryFactory
+            .selectFrom(board)
+            .where(board.category.eq(BoardCategory.FIND)
+                    .and(board.status.ne(BoardStatus.DELETED)))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+    List<BoardSimpleInfoResponseDto> dtoList = boards.stream()
+            .map(boardEntity -> new BoardSimpleInfoResponseDto(
+                    boardEntity.getUser().getUserId(),
+                    boardEntity.getUser().getNickname(),
+                    boardEntity.getLocation() != null ? boardEntity.getLocation().getLocationId() : null,
+                    boardEntity.getLocation() != null ? boardEntity.getLocation().getLocationName() : null,
+                    boardEntity.getTitle(),
+                    boardEntity.getRelatedDate(),
+                    boardEntity.getItemType()
+            ))
+            .collect(Collectors.toList());
+
+    long total = queryFactory
+            .selectFrom(board)
+            .where(board.category.eq(BoardCategory.FIND)
+                    .and(board.status.ne(BoardStatus.DELETED)))
+            .fetchCount();
+
+    return new PageImpl<>(dtoList, pageable, total);
+  }
 }
+


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #18

## 📌 작업 사항 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
사용자는 현재 올라온 ‘발견했어요’ 게시글 목록을 보기 위해 게시글 리스트를 조회한다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1. api/v1/boards/found와 api/v1/boards/lost GET API 개발
2. BoardController에 조회 로직 구현
3. 페이지네이션 적용
4. BoardCategory가 FIND 또는 LOST면서 BoardStatus가 DELETED가 아닌 게시물 리스트를 페이지 형태로 반환하는 로직 개발


## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
불필요한 데이터 전송을 줄이고, DTO로의 변환을 데이터베이스 레벨에서 직접 처리하는 방식으로 쿼리 리팩토링
쿼리 단계에서 바로 Projections.constructor()를 사용해 필요한 컬럼들만 선택적으로 조회하고 DTO를 생성함으로써 DTO 변환 작업을 데이터베이스 쿼리 내에서 처리합니다. 
이를 통해 메모리에서의 불필요한 객체 변환을 줄이고, 클라이언트로 전송되는 데이터만을 효율적으로 가져올 수 있습니다.


## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
