### PR TITLE
[feat] '잃었어요' 게시글 리스트 필터링 조회

### DIFF
--- a/ajoufinder/src/main/java/com/ajoufinder/api/controller/board/BoardController.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/controller/board/BoardController.java
@@ -7,6 +7,8 @@ import com.ajoufinder.api.controller.board.dto.response.BoardSimpleInfoResponseD
 import com.ajoufinder.api.service.board.BoardCommandService;
 import com.ajoufinder.api.service.board.BoardQueryService;
 import com.ajoufinder.domain.board.entity.Board;
+import com.ajoufinder.domain.board.entity.constant.BoardCategory;
+import com.ajoufinder.domain.board.entity.constant.BoardStatus;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -16,6 +18,9 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 @RestController
 @RequestMapping("api/v1/boards")
@@ -54,6 +59,18 @@ public class BoardController {
   public ResponseEntity<Page<BoardSimpleInfoResponseDto>> getFoundBoards(@PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable){
     Page<BoardSimpleInfoResponseDto> boards=boardQueryService.getFoundBoards(pageable);
     return new ResponseEntity<>(boards, HttpStatus.OK);
+  }
+
+  @GetMapping("/lost/filter")
+  public ResponseEntity<Page<BoardSimpleInfoResponseDto>> getBoardsByFilter(
+          @RequestParam(required = false) LocalDate date,  // yyyy-MM-dd 형식으로 받음 (선택적)
+          @RequestParam(required = false) LocalTime time, // HH:mm 형식으로 받음 (선택적)
+          @RequestParam(required = false) Long locationId,
+          @RequestParam(required = false) BoardStatus boardStatus,
+          Pageable pageable
+  ) {
+    Page<BoardSimpleInfoResponseDto> filteredBoards = boardQueryService.getBoardsByFilter(date, time, locationId, boardStatus, BoardCategory.LOST, pageable);
+    return ResponseEntity.ok(filteredBoards);
   }
 
   @PatchMapping("/{boardId}")

--- a/ajoufinder/src/main/java/com/ajoufinder/api/controller/board/dto/response/BoardSimpleInfoResponseDto.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/controller/board/dto/response/BoardSimpleInfoResponseDto.java
@@ -1,10 +1,10 @@
 package com.ajoufinder.api.controller.board.dto.response;
 
-import com.ajoufinder.domain.board.entity.constant.BoardStatus;
-import com.ajoufinder.domain.board.entity.constant.ItemType;
+import lombok.Builder;
 
 import java.time.LocalDateTime;
 
+@Builder
 public record BoardSimpleInfoResponseDto(
         Long boardId,
         Long userId,
@@ -13,8 +13,19 @@ public record BoardSimpleInfoResponseDto(
         String locationName,
         String title,
         LocalDateTime relatedDate,
-        ItemType itemType,
-        BoardStatus boardStatus
+        String itemType,
+        String boardStatus
 ) {
-
+  public static BoardSimpleInfoResponseDto from(BoardTempDto dto) {
+    return BoardSimpleInfoResponseDto.builder().boardId(dto.boardId())
+            .userId(dto.userId())
+            .nickname(dto.nickname())
+            .locationId(dto.locationId())
+            .locationName(dto.locationName())
+            .title(dto.title())
+            .relatedDate(dto.relatedDate())
+            .itemType(dto.itemType().getText())
+            .boardStatus(dto.boardStatus().getText())
+            .build();
+  }
 }

--- a/ajoufinder/src/main/java/com/ajoufinder/api/controller/board/dto/response/BoardTempDto.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/controller/board/dto/response/BoardTempDto.java
@@ -1,0 +1,20 @@
+package com.ajoufinder.api.controller.board.dto.response;
+
+import com.ajoufinder.domain.board.entity.constant.BoardStatus;
+import com.ajoufinder.domain.board.entity.constant.ItemType;
+
+import java.time.LocalDateTime;
+
+public record BoardTempDto(
+        Long boardId,
+        Long userId,
+        String nickname,
+        Long locationId,
+        String locationName,
+        String title,
+        LocalDateTime relatedDate,
+        ItemType itemType,
+        BoardStatus boardStatus
+) {
+
+}

--- a/ajoufinder/src/main/java/com/ajoufinder/api/controller/user/UserController.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/controller/user/UserController.java
@@ -1,6 +1,7 @@
 package com.ajoufinder.api.controller.user;
 
 import com.ajoufinder.api.controller.board.dto.response.BoardSimpleInfoResponseDto;
+import com.ajoufinder.api.controller.board.dto.response.BoardTempDto;
 import com.ajoufinder.api.controller.user.dto.request.UserCreateRequestDto;
 import com.ajoufinder.api.controller.user.dto.request.UserLoginRequestDto;
 import com.ajoufinder.api.controller.user.dto.response.UserCreateResponseDto;

--- a/ajoufinder/src/main/java/com/ajoufinder/api/service/board/BoardQueryService.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/service/board/BoardQueryService.java
@@ -2,17 +2,25 @@ package com.ajoufinder.api.service.board;
 
 import com.ajoufinder.api.controller.board.dto.response.BoardDetailInfoResponseDto;
 import com.ajoufinder.api.controller.board.dto.response.BoardSimpleInfoResponseDto;
+import com.ajoufinder.api.controller.board.dto.response.BoardTempDto;
+import com.ajoufinder.api.service.location.LocationQueryService;
 import com.ajoufinder.api.service.user.UserQueryService;
 import com.ajoufinder.common.exception.ExceptionCode;
 import com.ajoufinder.common.exception.board.BoardException;
 import com.ajoufinder.domain.board.entity.Board;
+import com.ajoufinder.domain.board.entity.constant.BoardCategory;
+import com.ajoufinder.domain.board.entity.constant.BoardStatus;
 import com.ajoufinder.domain.board.repository.BoardRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -20,6 +28,7 @@ import java.util.List;
 public class BoardQueryService {
   private final BoardRepository boardRepository;
   private final UserQueryService userQueryService;
+  private final LocationQueryService locationQueryService;
 
   public Board getBoardByIdOrThrow(Long boardId) {
     return boardRepository.findById(boardId).orElseThrow(()->new BoardException(ExceptionCode.NOT_FOUND_BOARD));
@@ -34,15 +43,50 @@ public class BoardQueryService {
   }
 
   public Page<BoardSimpleInfoResponseDto> getLostBoards(Pageable pageable) {
-    return boardRepository.getAllLostBoards(pageable);
+    Page<BoardTempDto>boardTempDtos= boardRepository.getAllLostBoards(pageable);
+    return boardTempDtos.map(BoardSimpleInfoResponseDto::from);
   }
 
   public Page<BoardSimpleInfoResponseDto> getFoundBoards(Pageable pageable) {
-    return boardRepository.getAllFoundBoards(pageable);
+    Page<BoardTempDto>boardTempDtos= boardRepository.getAllFoundBoards(pageable);
+    return boardTempDtos.map(BoardSimpleInfoResponseDto::from);
   }
 
   public List<BoardSimpleInfoResponseDto> getBoardsByUserId(Long userId) {
     userQueryService.getUserByIdOrThrow(userId);
-    return boardRepository.getBoardsByUserId(userId);
+    List<BoardTempDto>boardTempDtos= boardRepository.getBoardsByUserId(userId);
+    return boardTempDtos.stream().map(BoardSimpleInfoResponseDto::from)
+            .collect(Collectors.toList());
+  }
+
+  public Page<BoardSimpleInfoResponseDto> getBoardsByFilter(
+          LocalDate date,
+          LocalTime time,
+          Long locationId,
+          BoardStatus boardStatus,
+          BoardCategory boardCategory,
+          Pageable pageable
+  ) {
+    LocalDateTime start = null;
+    LocalDateTime end = null;
+
+    if (locationId != null) {
+      locationQueryService.findLocationByIdOrThrow(locationId);
+    }
+
+    if (date != null) {
+      if (time != null) {
+        start = date.atTime(time);
+        end = start.plusHours(1);
+      }else {
+        start = date.atStartOfDay();
+        end = date.plusDays(1).atStartOfDay();
+      }
+    } else if (time != null) {
+      throw new BoardException(ExceptionCode.INVALID_TIME_WITHOUT_DATE);
+    }
+
+    Page<BoardTempDto> boardTempDtos= boardRepository.getBoardsByFilter(start, end, locationId, boardStatus, boardCategory, pageable);
+    return boardTempDtos.map(BoardSimpleInfoResponseDto::from);
   }
 }

--- a/ajoufinder/src/main/java/com/ajoufinder/common/exception/ExceptionCode.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/common/exception/ExceptionCode.java
@@ -17,7 +17,8 @@ public enum ExceptionCode{
 
   //Board
   NOT_FOUND_BOARD(404, "존재하지 않는 게시물입니다."),
-  ALREADY_DELETED_BOARD(400,"이미 삭제된 게시물입니다.");
+  ALREADY_DELETED_BOARD(400,"이미 삭제된 게시물입니다."),
+  INVALID_TIME_WITHOUT_DATE(400, "날짜가 없고 시간만 제공된 경우 조회할 수 없습니다.");
 
   private final int code;
   private final String message;

--- a/ajoufinder/src/main/java/com/ajoufinder/common/exception/GlobalExceptionHandler.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/common/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice
 @Slf4j
@@ -18,5 +19,11 @@ public class GlobalExceptionHandler {
     return ResponseEntity
             .status(e.getExceptionCode().getCode())
             .body(new ExceptionResponse(e.getExceptionCode().getCode(), e.getMessage()));
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<String> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException ex) {
+    String message = "입력된 값의 형식이 잘못되었습니다. 날짜는 yyyy-MM-dd 형식, 시간은 HH:mm 형식이어야 합니다.";
+    return ResponseEntity.badRequest().body(message);
   }
 }

--- a/ajoufinder/src/main/java/com/ajoufinder/domain/board/repository/custom/BoardRepositoryCustom.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/domain/board/repository/custom/BoardRepositoryCustom.java
@@ -1,19 +1,24 @@
 package com.ajoufinder.domain.board.repository.custom;
 
 import com.ajoufinder.api.controller.board.dto.response.BoardDetailInfoResponseDto;
-import com.ajoufinder.api.controller.board.dto.response.BoardSimpleInfoResponseDto;
+import com.ajoufinder.api.controller.board.dto.response.BoardTempDto;
+import com.ajoufinder.domain.board.entity.constant.BoardCategory;
+import com.ajoufinder.domain.board.entity.constant.BoardStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 
 public interface BoardRepositoryCustom {
   BoardDetailInfoResponseDto findBoardWithUserAndLocation(Long boardId);
 
-  Page<BoardSimpleInfoResponseDto> getAllLostBoards(Pageable pageable);
+  Page<BoardTempDto> getAllLostBoards(Pageable pageable);
 
-  Page<BoardSimpleInfoResponseDto> getAllFoundBoards(Pageable pageable);
+  Page<BoardTempDto> getAllFoundBoards(Pageable pageable);
 
-  List<BoardSimpleInfoResponseDto> getBoardsByUserId(Long userId);
+  List<BoardTempDto> getBoardsByUserId(Long userId);
+
+  Page<BoardTempDto> getBoardsByFilter(LocalDateTime start, LocalDateTime end, Long locationId, BoardStatus boardStatus, BoardCategory boardCategory,Pageable pageable);
 }


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #29 

## 📌 작업 사항 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 간략 설명 
사용자가 선택한 분실 날짜, 분실 시간, 위치, 게시물 상태를 기준으로 조회할 수 있다. 
사용자는 분실 날짜, 분실 시간, 위치, 게시물 상태 중 일부의 조건만 설정할 수도 있다. (즉, 조건 항목에 null이 들어갈 수도 있다.)
사용자가 설정한 시간으로부터 1시간동안 발생한 분실물을 확인가능하다.(1시간 단위로 조회)

분실 날짜  / 분실 시간
      o / o           -> 해당 날짜와 시간에 발생된 분실물
      o / x            -> 해당 날짜에 발생된 분실물
      x / o            -> 날짜 입력 없이 시간만 입력한 경우 예외처리
      x / x            -> 날짜, 시간 조건 없이 분실물 조회



## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1.  필터링 조건을 받는 RequestParam 개발
2. RequestParam 중 LocalDate,LocalTime형식에 맞게 들어왔는지 검증 후 형식오류 발견시 글로벌예외처리
3. /api/v1/boards/lost/filter GET API 개발
4.  '잃었어요' 게시글 리스트를 분실 시간/분실 위치/게시글 상태 조건에 맞게 필터링하여 조회하는 비즈니스 로직 구현
5. 분실 시간/분실 위치/게시글 상태 조건에 맞게 조회하는 QueryDsl 커스텀 메소드 개발



## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
