### PR TITLE
[feat]SecurityConfig 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ ajoufinder/src/main/generated/
 
 # ENV FILE
 .env
+
+#Docker File
+Dockerfile

--- a/ajoufinder/build.gradle
+++ b/ajoufinder/build.gradle
@@ -73,9 +73,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // jwt
-//    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
-//    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
-//    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
     // spring security
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/ajoufinder/src/main/java/com/ajoufinder/api/service/user/UserCommandService.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/api/service/user/UserCommandService.java
@@ -18,8 +18,12 @@ import org.springframework.stereotype.Service;
 public class UserCommandService {
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
+  private final UserQueryService userQueryService;
 
   public User createUser(UserCreateRequestDto dto) {
+    if(userQueryService.existsByEmail(dto.email())){
+      throw new UserException(ExceptionCode.DUPLICATED_USER_EMAIL);
+    }
     User user=dto.toEntity();
     user.passwordEncode(passwordEncoder);
     userRepository.save(user);

--- a/ajoufinder/src/main/java/com/ajoufinder/common/config/SecurityConfig.java
+++ b/ajoufinder/src/main/java/com/ajoufinder/common/config/SecurityConfig.java
@@ -1,37 +1,64 @@
 package com.ajoufinder.common.config;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.SecurityBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
-@EnableWebSecurity
-@RequiredArgsConstructor
+@EnableWebSecurity()
 public class SecurityConfig {
   @Bean
   public PasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
   }
+//FilterChainProxy는 여러개의 SecurityFilterChain을 가질 수 있다.
+// 개발자는 SecurityFilterChain을 정의하여 여러 보안을 구현한다.
+//  http.securityMatchers 메소드는 SecurityFilterChain이 담당할 경로를 설정한다.이 설정을 안해주면 모든 경로가 이 SecurityFilterChain에 들어오게 된다.
+//  http.authorizeHttpRequests 메소드는 경로에 대한 접근 권한을 설정한다.
 
   @Bean
-  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+  public SecurityFilterChain configure(HttpSecurity http)throws Exception{
+    //csrf disable
     http
-            .csrf().disable() // CSRF 보호 비활성화
-            .authorizeHttpRequests(authorize -> authorize
-                    .requestMatchers(
-                            "/v3/api-docs/**",         // OpenAPI 문서 경로
-                            "/swagger-ui/**",          // Swagger UI 경로
-                            "/swagger-ui/index.html",  // Swagger UI 인덱스
-                            "/webjars/**"              // Swagger UI에 필요한 웹 자원
-                    ).permitAll() // 인증 없이 접근 허용
-                    .anyRequest().permitAll() // 모든 요청에 대해 접근 허용
-            );
+            .csrf((auth) -> auth.disable());
+
+    //From 로그인 방식 disable
+    http
+            .formLogin((auth) -> auth.disable());
+
+    //http basic 인증 방식 disable
+    http
+            .httpBasic((auth) -> auth.disable());
+
+    //경로별 인가 작업
+    http.authorizeHttpRequests(auth->auth
+            .requestMatchers("/login","/register","/").permitAll()
+            .anyRequest().authenticated());
+
+    //세션 설정
+    http
+            .sessionManagement((session) -> session
+                    .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
     return http.build();
+  }
+
+
+//  WebSecurityCustomizer는 내부에 필터가 하나도 없는 SecurityFilterChain이 0번 인덱스로 생성된다.
+//  WebSecurityCustomizer를 통해 특정 경로에 대해서 어떤 필터도 통과하지 않도록 설정할 수 있다.
+    @Bean
+  public WebSecurityCustomizer webSecurityCustomizer(){
+    return web->web.ignoring().requestMatchers("/v3/api-docs/**",         // OpenAPI 문서 경로
+            "/swagger-ui/**",          // Swagger UI 경로
+            "/swagger-ui/index.html",  // Swagger UI 인덱스
+            "/webjars/**",
+            "/index.html"
+    );// Swagger UI에 필요한 웹 자원와 어플리케이션 정적 리소스)
   }
 }


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #37

## 📌 작업 사항 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
JWT+Security 이용한 보안 구현을 위해 필요한 의존성을 추가하고, SecurityConfig클래스를 구현한다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- build.gradle
 jwt, security 관련 의존성 추가

- SecurityConfig
 swagger 문서 및 프로젝트 내 정적 리소스에 대한 접근을 언제나 허용하기 위해 FilterChainProxy에 비어있는 SecurityFilterChain을 0번 인덱스로 등록
 SecurityFilterChain 1번 인덱스 생성하여 어플리케이션 수준의 보안을 구현 (SecurityFilterChain 내 인증, 인가, csrf 등의 보안 관련 필터를 추가하거나 기존 필터를 해제)

- UserCommandService
 회원가입 시 이미 존재하는 유저인지에 대한 검증 로직 추가


## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
